### PR TITLE
Success

### DIFF
--- a/scripts/interop-test.ts
+++ b/scripts/interop-test.ts
@@ -1,82 +1,130 @@
 import { ethers } from "hardhat";
-import { Contract, Provider, types, utils, Wallet } from "zksync-ethers";
-import { getGWBlockNumber, waitForInteropRootNonZero, waitForL2ToL1LogProof } from "../utils/interop-utils";
-import * as L2_MESSAGE_V_JSON from "../utils/L2MessageVerification.json"
+import { Contract, Provider, utils, Wallet } from "zksync-ethers";
+import * as L2_MESSAGE_V_JSON from "../utils/L2MessageVerification.json";
+
 const PRIVATE_KEY = process.env.WALLET_PRIVATE_KEY;
 
+const DST_L2_RPC = process.env.DST_L2_RPC ?? "http://localhost:3350";
+const GW_RPC     = process.env.GW_RPC     ?? "http://localhost:3250";
+const GW_CHAIN_ID = BigInt(process.env.GW_CHAIN_ID ?? "506");
+
+async function sleep(ms: number) { return new Promise((r) => setTimeout(r, ms)); }
+
 async function main() {
-  if (!PRIVATE_KEY) {
-    throw new Error("Missing PRIVATE_KEY");
-  }
+  if (!PRIVATE_KEY) throw new Error("Missing PRIVATE_KEY");
+
+  // Source 
   const providerl2 = new Provider("http://localhost:3050");
   const providerl1 = new Provider("http://localhost:8545");
   const wallet = new Wallet(PRIVATE_KEY, providerl2, providerl1);
+
+  const providerDst = new Provider(DST_L2_RPC);
+  const dstWallet   = new Wallet(PRIVATE_KEY, providerDst, providerl1);
+  const gw          = new ethers.JsonRpcProvider(GW_RPC);
+
   console.log("Using signer:", wallet.address);
   const balance = await ethers.provider.getBalance(wallet.address);
   console.log("Signer balance:", ethers.formatEther(balance));
+
   const L1Messenger = new Contract(utils.L1_MESSENGER_ADDRESS, utils.L1_MESSENGER, wallet);
 
   // Send message to L1 and wait until it gets there.
   const message = ethers.toUtf8Bytes("Some L2->L1 message");
   const tx = await L1Messenger.sendToL1(message);
-  console.log('waiting for receipt...')
-  const receipt = await (
-    await wallet.provider.getTransaction(tx.hash)
-  ).waitFinalize();
+  console.log("waiting for receipt...");
+  const receipt = await (await wallet.provider.getTransaction(tx.hash)).waitFinalize();
   console.log("got tx receipt");
 
-  // Get the proof for the sent message from the server, expect it to exist.
-  const l2ToL1LogIndex = receipt.l2ToL1Logs.findIndex(
-    (log: types.L2ToL1Log) => log.sender == utils.L1_MESSENGER_ADDRESS
+  // Find the exact interop log: sender=0x…8008, key=pad32(EOA), value=keccak(message)
+  const paddedEOA = ethers.zeroPadValue(wallet.address, 32);
+  const msgHash = ethers.keccak256(message);
+  const l2ToL1LogIndex = receipt.l2ToL1Logs.findIndex((log: any) =>
+    log.sender.toLowerCase() === utils.L1_MESSENGER_ADDRESS.toLowerCase() &&
+    log.key.toLowerCase()    === paddedEOA.toLowerCase() &&
+    log.value.toLowerCase()  === msgHash.toLowerCase()
   );
   console.log("l2ToL1LogIndex", l2ToL1LogIndex);
-  await waitForL2ToL1LogProof(wallet, receipt.blockNumber, tx.hash);
+  if (l2ToL1LogIndex < 0) throw new Error("Could not find our interop log in receipt.l2ToL1Logs");
 
-  const params = await wallet.finalizeWithdrawalParams(tx.hash);
-  console.log("params:", params)
-  
-  const msgProof = await wallet.provider.getLogProof(tx.hash, l2ToL1LogIndex);
+  // (Optional) L1 verification
+  // await waitForL2ToL1LogProof(wallet, receipt.blockNumber, tx.hash);
+  // const params = await wallet.finalizeWithdrawalParams(tx.hash);
+  // const msgProof = await wallet.provider.getLogProof(tx.hash, l2ToL1LogIndex);
+  // const { id, proof } = msgProof!;
+  // const chainContract = await wallet.getMainContract();
+  // const result = await chainContract.proveL2MessageInclusion(
+  //   receipt.l1BatchNumber!, id,
+  //   { txNumberInBatch: receipt.l1BatchTxIndex!, sender: wallet.address, data: message },
+  //   proof
+  // );
+  // console.log("included on l1:", result);
 
-  const { id, proof } = msgProof!;
+  // fetch the gw proof
+  const gwProofResp = await wallet.provider.send("zks_getL2ToL1LogProof", [
+    tx.hash,
+    l2ToL1LogIndex,
+    "proof_based_gw",
+  ]);
+  if (!gwProofResp?.proof) throw new Error("Gateway proof not ready yet");
+  const gwProof: string[] = gwProofResp.proof;
+  console.log("GW proof nodes:", gwProof.length);
 
-  // Ensure that provided proof is accepted by the main ZKsync contract.
-  const chainContract = await wallet.getMainContract();
-  const result = await chainContract.proveL2MessageInclusion(
-    receipt.l1BatchNumber!,
-    id,
-    {
-      txNumberInBatch: receipt.l1BatchTxIndex!,
-      sender: wallet.address,
-      data: message,
-    },
-    proof
+  // fetch executeTxHash
+  async function getGwBlockForBatch(batch: bigint): Promise<bigint> {
+    while (true) {
+      const details = await wallet.provider.send("zks_getL1BatchDetails", [Number(batch)]);
+      const execTx: string | null =
+        details?.executeTxHash &&
+        details.executeTxHash !== "0x0000000000000000000000000000000000000000000000000000000000000000"
+          ? details.executeTxHash
+          : null;
+      if (execTx) {
+        const gwRcpt = await gw.getTransactionReceipt(execTx);
+        if (gwRcpt?.blockNumber !== undefined) return BigInt(gwRcpt.blockNumber);
+      }
+      await sleep(1000);
+    }
+  }
+  const gwBlock = await getGwBlockForBatch(BigInt(receipt.l1BatchNumber!));
+
+  // fetch the interop root from destiination chain
+  const INTEROP_ROOT_STORAGE = "0x0000000000000000000000000000000000010008";
+  const InteropRootStorage = new Contract(
+    INTEROP_ROOT_STORAGE,
+    ["function interopRoots(uint256,uint256) view returns (bytes32)"],
+    dstWallet
+  );
+  async function waitDstHasGwRoot(timeoutMs = 120_000): Promise<string> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const root: string = await InteropRootStorage.interopRoots(GW_CHAIN_ID, gwBlock);
+      if (root && root !== "0x" + "0".repeat(64)) return root;
+      // send tx just to get dst to seal batch
+      const t = await dstWallet.sendTransaction({ to: dstWallet.address, value: BigInt(1) });
+      await (await dstWallet.provider.getTransaction(t.hash)).waitFinalize();
+    }
+    throw new Error(`DST did not import interop root for (${GW_CHAIN_ID}, ${gwBlock}) in time`);
+  }
+  const dstRoot = await waitDstHasGwRoot();
+  console.log(`DST interop root ready: interopRoots(${GW_CHAIN_ID}, ${gwBlock}) = ${dstRoot}`);
+
+  // verify on DST using source chain
+  const L2_MESSAGE_VERIFICATION_ADDRESS = "0x0000000000000000000000000000000000010009";
+  const l2MessageVerification = new Contract(
+    L2_MESSAGE_VERIFICATION_ADDRESS,
+    L2_MESSAGE_V_JSON.abi,
+    dstWallet
   );
 
-  console.log("included on l1:", result);
-
-  // Needed else the L2's view of GW's MessageRoot won't be updated
-  await waitForInteropRootNonZero(wallet.provider, wallet, getGWBlockNumber(params));
-  console.log('interop root is non zero')
-
-  const L2_MESSAGE_VERIFICATION_ADDRESS = '0x0000000000000000000000000000000000010009';
-  
-  const l2MessageVerificationAbi = L2_MESSAGE_V_JSON.abi;
-   const l2MessageVerification = new Contract(
-            L2_MESSAGE_VERIFICATION_ADDRESS,
-            l2MessageVerificationAbi,
-            wallet
-        );
-
-console.log("requesting...")
-
+  const srcChainId = (await wallet.provider.getNetwork()).chainId;
   const included = await l2MessageVerification.proveL2MessageInclusionShared(
-    (await wallet.provider.getNetwork()).chainId,
-    params.l1BatchNumber,
-    params.l2MessageIndex,
-    { txNumberInBatch: params.l2TxNumberInBlock, sender: params.sender, data: params.message },
-    params.proof
-);
-  console.log("l2 proved:", included)
+    srcChainId,
+    receipt.l1BatchNumber!,
+    receipt.l1BatchTxIndex!,                             // mask/index
+    { txNumberInBatch: receipt.l1BatchTxIndex!, sender: wallet.address, data: message },
+    gwProof
+  );
+  console.log("l2 proved:", included);
 }
 
 main()


### PR DESCRIPTION
Success! 

Followed the somewhat outdated steps from Marcin here: https://github.com/mm-zk/zksync_tools/blob/main/simple_interop/README.md

Output:

```
npm run interop

> interop
> hardhat run ./scripts/interop-test.ts

Using signer: 0x36615Cf349d7F6344891B1e7CA7C72883F5dc049
Signer balance: 0.99960516385
waiting for receipt...
got tx receipt
l2ToL1LogIndex 0
GW proof nodes: 27
DST interop root ready: interopRoots(506, 103) = 0xba739a00d877861581075c14496fb95d14d7fff68cdb635a83cdde63a87f5197
l2 proved: true
```


## Setup instructions

Note: you can adapt the script found here accordingly: https://github.com/matter-labs/zksync-era/blob/main/infrastructure/scripts/interop.sh

### 1. Clone & Install

```bash
git clone git@github.com:matter-labs/zksync-era.git
cd zksync-era
git submodule update --init --recursive

# Install zkstack CLI from local source
cargo install --path zkstack_cli/crates/zkstack --force --locked
```

---

### 2. Start Base Environment

```bash
# Clean and start dev containers
zkstack dev clean containers
zkstack up -o false

# Deploy base contracts for dev environment
zkstack dev contracts
```

---

### 3. Initialize Era Chain

```bash
zkstack ecosystem init \
    --deploy-paymaster --deploy-erc20 --deploy-ecosystem \
    --l1-rpc-url=http://localhost:8545 \
    --server-db-url=postgres://postgres:notsecurepassword@localhost:5432 \
    --server-db-name=zksync_server_localhost_era \
    --ignore-prerequisites --observability=false \
    --chain era \
    --update-submodules false

# Generate genesis block for Era
zkstack dev generate-genesis

# (Re-run ecosystem init to finalize configuration)
zkstack ecosystem init \
    --deploy-paymaster --deploy-erc20 --deploy-ecosystem \
    --l1-rpc-url=http://localhost:8545 \
    --server-db-url=postgres://postgres:notsecurepassword@localhost:5432 \
    --server-db-name=zksync_server_localhost_era \
    --ignore-prerequisites --observability=false \
    --chain era \
    --update-submodules false
```

---

### 4. Create & Init DUT Chain (can be any chain name lol 😄 )

```bash
zkstack chain create \
    --chain-name dut \
    --chain-id 260 \
    --prover-mode no-proofs \
    --wallet-creation localhost \
    --l1-batch-commit-data-generator-mode rollup \
    --base-token-address 0x0000000000000000000000000000000000000001 \
    --base-token-price-nominator 1 \
    --base-token-price-denominator 1 \
    --set-as-default false \
    --evm-emulator false \
    --ignore-prerequisites --update-submodules false 

zkstack chain init \
    --deploy-paymaster \
    --l1-rpc-url=http://localhost:8545 \
    --server-db-url=postgres://postgres:notsecurepassword@localhost:5432 \
    --server-db-name=zksync_server_localhost_dut \
    --chain dut \
    --update-submodules false
```

---

### 5. Create & Init Gateway Chain

```bash
zkstack chain create \
    --chain-name gateway \
    --chain-id 506 \
    --prover-mode no-proofs \
    --wallet-creation localhost \
    --l1-batch-commit-data-generator-mode rollup \
    --base-token-address 0x0000000000000000000000000000000000000001 \
    --base-token-price-nominator 1 \
    --base-token-price-denominator 1 \
    --set-as-default false \
    --evm-emulator false \
    --ignore-prerequisites --update-submodules false 

zkstack chain init \
    --deploy-paymaster \
    --l1-rpc-url=http://localhost:8545 \
    --server-db-url=postgres://postgres:notsecurepassword@localhost:5432 \
    --server-db-name=zksync_server_localhost_gateway \
    --chain gateway \
    --update-submodules false
```

---

### 6. Convert Gateway & Start Server

```bash
# Convert gateway chain to gateway mode
zkstack chain gateway convert-to-gateway --chain gateway --ignore-prerequisites

# Write gateway-specific config
zkstack dev config-writer --path etc/env/file_based/overrides/tests/gateway.yaml --chain gateway

# Start gateway server
zkstack server --ignore-prerequisites --chain gateway
zkstack server wait --ignore-prerequisites --verbose --chain gateway
```

---

### 7. Migrate Era & DUT to Gateway

```bash
zkstack chain gateway migrate-to-gateway --chain era --gateway-chain-name gateway
zkstack chain gateway migrate-to-gateway --chain dut --gateway-chain-name gateway
```

---

### 8. Start Era & DUT Servers

```bash
zkstack server --ignore-prerequisites --chain era
zkstack server wait --ignore-prerequisites --verbose --chain era

zkstack server --ignore-prerequisites --chain dut
zkstack server wait --ignore-prerequisites --verbose --chain dut
```

